### PR TITLE
[WIP] Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ $(EMOJI).ttf: check_sequence $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
 	@mv "$@-with-pua-varsel" "$@"
 	@rm "$@-with-pua"
 
-$(EMOJI_WINDOWS).ttf: check_sequence $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
+$(EMOJI_WINDOWS).ttf: check_sequence $(EMOJI_WINDOWS).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
 	$(ALL_COMPRESSED_FILES) | check_tools
 
 	@$(PYTHON) $(EMOJI_BUILDER) -O $(SMALL_METRICS) -V $(word 2,$^) "$@" "$(COMPRESSED_DIR)/emoji_u"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 EMOJI = NotoColorEmoji
-font: $(EMOJI).ttf
+EMOJI_WINDOWS = NotoColorEmoji_WindowsCompatible
+all: $(EMOJI).ttf $(EMOJI_WINDOWS).ttf
 
 CFLAGS = -std=c99 -Wall -Wextra `pkg-config --cflags --libs cairo`
 LDFLAGS = -lm `pkg-config --libs cairo`
@@ -30,8 +31,6 @@ TTX = ttx
 EMOJI_BUILDER = third_party/color_emoji/emoji_builder.py
 # flag for emoji builder.  Default to legacy small metrics for the time being.
 SMALL_METRICS := -S
-# keep outline tables and related tables
-KEEP_GLYF := -O
 ADD_GLYPHS = add_glyphs.py
 ADD_GLYPHS_FLAGS = -a emoji_aliases.txt
 PUA_ADDER = map_pua_emoji.py
@@ -110,7 +109,7 @@ RESIZED_FLAG_FILES = $(addprefix $(RESIZED_FLAGS_DIR)/, $(FLAG_NAMES))
 ifndef MISSING_PY_TOOLS
 FLAG_GLYPH_NAMES = $(shell $(PYTHON) flag_glyph_name.py $(FLAGS))
 else
-FLAG_GLYPH_NAMES = 
+FLAG_GLYPH_NAMES =
 endif
 RENAMED_FLAG_NAMES = $(FLAG_GLYPH_NAMES:%=emoji_%.png)
 RENAMED_FLAG_FILES = $(addprefix $(RENAMED_FLAGS_DIR)/, $(RENAMED_FLAG_NAMES))
@@ -202,7 +201,9 @@ $(COMPRESSED_DIR)/%.png: $(QUANTIZED_DIR)/%.png | check_tools $(COMPRESSED_DIR)
 # Run make without -j if this happens.
 
 %.ttx: %.ttx.tmpl $(ADD_GLYPHS) $(ALL_COMPRESSED_FILES)
-	@$(PYTHON) $(ADD_GLYPHS) -f "$<" -o "$@" -d "$(COMPRESSED_DIR)" $(ADD_GLYPHS_FLAGS)
+	# TODO: make distinction between EMOJI and EMOJI_WINDOWS, and add
+	# --add_cmap4 flag for EMOJI_WINDOWS
+	$(PYTHON) $(ADD_GLYPHS) -f "$<" -o "$@" -d "$(COMPRESSED_DIR)" $(ADD_GLYPHS_FLAGS)
 
 %.ttf: %.ttx
 	@rm -f "$@"
@@ -211,11 +212,21 @@ $(COMPRESSED_DIR)/%.png: $(QUANTIZED_DIR)/%.png | check_tools $(COMPRESSED_DIR)
 $(EMOJI).ttf: check_sequence $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
 	$(ALL_COMPRESSED_FILES) | check_tools
 
-	@$(PYTHON) $(EMOJI_BUILDER) $(KEEP_GLYF) $(SMALL_METRICS) -V $(word 2,$^) "$@" "$(COMPRESSED_DIR)/emoji_u"
+	@$(PYTHON) $(EMOJI_BUILDER) $(SMALL_METRICS) -V $(word 2,$^) "$@" "$(COMPRESSED_DIR)/emoji_u"
 	@$(PYTHON) $(PUA_ADDER) "$@" "$@-with-pua"
 	@$(VS_ADDER) -vs 2640 2642 2695 --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"
 	@mv "$@-with-pua-varsel" "$@"
 	@rm "$@-with-pua"
+
+$(EMOJI_WINDOWS).ttf: check_sequence $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
+	$(ALL_COMPRESSED_FILES) | check_tools
+
+	@$(PYTHON) $(EMOJI_BUILDER) -O $(SMALL_METRICS) -V $(word 2,$^) "$@" "$(COMPRESSED_DIR)/emoji_u"
+	@$(PYTHON) $(PUA_ADDER) "$@" "$@-with-pua"
+	@$(VS_ADDER) -vs 2640 2642 2695 --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"
+	@mv "$@-with-pua-varsel" "$@"
+	@rm "$@-with-pua"
+
 
 check_sequence:
 ifdef BYPASS_SEQUENCE_CHECK
@@ -225,7 +236,7 @@ else
 endif
 
 clean:
-	rm -f $(EMOJI).ttf $(EMOJI).tmpl.ttf $(EMOJI).tmpl.ttx
+	rm -f $(EMOJI).ttf $(EMOJI_WINDOWS).ttf $(EMOJI).tmpl.ttf $(EMOJI_WINDOWS).tmpl.ttf $(EMOJI).tmpl.ttx $(EMOJI_WINDOWS).tmpl.ttx
 	rm -f waveflag
 	rm -rf $(BUILD_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ TTX = ttx
 EMOJI_BUILDER = third_party/color_emoji/emoji_builder.py
 # flag for emoji builder.  Default to legacy small metrics for the time being.
 SMALL_METRICS := -S
+# keep outline tables and related tables
+KEEP_GLYF := -O
 ADD_GLYPHS = add_glyphs.py
 ADD_GLYPHS_FLAGS = -a emoji_aliases.txt
 PUA_ADDER = map_pua_emoji.py
@@ -209,7 +211,7 @@ $(COMPRESSED_DIR)/%.png: $(QUANTIZED_DIR)/%.png | check_tools $(COMPRESSED_DIR)
 $(EMOJI).ttf: check_sequence $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
 	$(ALL_COMPRESSED_FILES) | check_tools
 
-	@$(PYTHON) $(EMOJI_BUILDER) $(SMALL_METRICS) -V $(word 2,$^) "$@" "$(COMPRESSED_DIR)/emoji_u"
+	@$(PYTHON) $(EMOJI_BUILDER) $(KEEP_GLYF) $(SMALL_METRICS) -V $(word 2,$^) "$@" "$(COMPRESSED_DIR)/emoji_u"
 	@$(PYTHON) $(PUA_ADDER) "$@" "$@-with-pua"
 	@$(VS_ADDER) -vs 2640 2642 2695 --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"
 	@mv "$@-with-pua-varsel" "$@"

--- a/Makefile
+++ b/Makefile
@@ -200,10 +200,11 @@ $(COMPRESSED_DIR)/%.png: $(QUANTIZED_DIR)/%.png | check_tools $(COMPRESSED_DIR)
 # ...
 # Run make without -j if this happens.
 
-%.ttx: %.ttx.tmpl $(ADD_GLYPHS) $(ALL_COMPRESSED_FILES)
-	# TODO: make distinction between EMOJI and EMOJI_WINDOWS, and add
-	# --add_cmap4 flag for EMOJI_WINDOWS
+$(EMOJI).tmpl.ttx: $(EMOJI).tmpl.ttx.tmpl $(ADD_GLYPHS) $(ALL_COMPRESSED_FILES)
 	$(PYTHON) $(ADD_GLYPHS) -f "$<" -o "$@" -d "$(COMPRESSED_DIR)" $(ADD_GLYPHS_FLAGS)
+
+$(EMOJI_WINDOWS).tmpl.ttx: $(EMOJI_WINDOWS).tmpl.ttx.tmpl $(ADD_GLYPHS) $(ALL_COMPRESSED_FILES)
+	$(PYTHON) $(ADD_GLYPHS) --add_cmap4 -f "$<" -o "$@" -d "$(COMPRESSED_DIR)" $(ADD_GLYPHS_FLAGS)
 
 %.ttf: %.ttx
 	@rm -f "$@"

--- a/NotoColorEmoji.tmpl.ttx.tmpl
+++ b/NotoColorEmoji.tmpl.ttx.tmpl
@@ -229,6 +229,83 @@
     </cmap_format_12>
   </cmap>
 
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+    <TTGlyph name=".notdef"/>
+    <TTGlyph name="null"/>
+    <TTGlyph name="nonmarkingreturn"/>
+    <TTGlyph name="space"/>
+    <TTGlyph name="uni200D"/>
+    <TTGlyph name="uE0030"/>
+    <TTGlyph name="uE0031"/>
+    <TTGlyph name="uE0032"/>
+    <TTGlyph name="uE0033"/>
+    <TTGlyph name="uE0034"/>
+    <TTGlyph name="uE0035"/>
+    <TTGlyph name="uE0036"/>
+    <TTGlyph name="uE0037"/>
+    <TTGlyph name="uE0038"/>
+    <TTGlyph name="uE0039"/>
+    <TTGlyph name="uE0061"/>
+    <TTGlyph name="uE0062"/>
+    <TTGlyph name="uE0063"/>
+    <TTGlyph name="uE0064"/>
+    <TTGlyph name="uE0065"/>
+    <TTGlyph name="uE0066"/>
+    <TTGlyph name="uE0067"/>
+    <TTGlyph name="uE0068"/>
+    <TTGlyph name="uE0069"/>
+    <TTGlyph name="uE006A"/>
+    <TTGlyph name="uE006B"/>
+    <TTGlyph name="uE006C"/>
+    <TTGlyph name="uE006D"/>
+    <TTGlyph name="uE006E"/>
+    <TTGlyph name="uE006F"/>
+    <TTGlyph name="uE0070"/>
+    <TTGlyph name="uE0071"/>
+    <TTGlyph name="uE0072"/>
+    <TTGlyph name="uE0073"/>
+    <TTGlyph name="uE0074"/>
+    <TTGlyph name="uE0075"/>
+    <TTGlyph name="uE0076"/>
+    <TTGlyph name="uE0077"/>
+    <TTGlyph name="uE0078"/>
+    <TTGlyph name="uE0079"/>
+    <TTGlyph name="uE007A"/>
+    <TTGlyph name="uE007F"/>
+    <TTGlyph name="u1F3F4"/>
+    <TTGlyph name="uFE82B"/>
+    <TTGlyph name="u1F1E6"/>
+    <TTGlyph name="u1F1E7"/>
+    <TTGlyph name="u1F1E8"/>
+    <TTGlyph name="u1F1E9"/>
+    <TTGlyph name="u1F1EA"/>
+    <TTGlyph name="u1F1EB"/>
+    <TTGlyph name="u1F1EC"/>
+    <TTGlyph name="u1F1ED"/>
+    <TTGlyph name="u1F1EE"/>
+    <TTGlyph name="u1F1EF"/>
+    <TTGlyph name="u1F1F0"/>
+    <TTGlyph name="u1F1F1"/>
+    <TTGlyph name="u1F1F2"/>
+    <TTGlyph name="u1F1F3"/>
+    <TTGlyph name="u1F1F4"/>
+    <TTGlyph name="u1F1F5"/>
+    <TTGlyph name="u1F1F6"/>
+    <TTGlyph name="u1F1F7"/>
+    <TTGlyph name="u1F1F8"/>
+    <TTGlyph name="u1F1F9"/>
+    <TTGlyph name="u1F1FA"/>
+    <TTGlyph name="u1F1FB"/>
+    <TTGlyph name="u1F1FC"/>
+    <TTGlyph name="u1F1FD"/>
+    <TTGlyph name="u1F1FE"/>
+    <TTGlyph name="u1F1FF"/>
+  </glyf>
+
   <name>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2013 Google Inc.

--- a/NotoColorEmoji_WindowsCompatible.tmpl.ttx.tmpl
+++ b/NotoColorEmoji_WindowsCompatible.tmpl.ttx.tmpl
@@ -229,6 +229,83 @@
     </cmap_format_12>
   </cmap>
 
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+    <TTGlyph name=".notdef"/>
+    <TTGlyph name="null"/>
+    <TTGlyph name="nonmarkingreturn"/>
+    <TTGlyph name="space"/>
+    <TTGlyph name="uni200D"/>
+    <TTGlyph name="uE0030"/>
+    <TTGlyph name="uE0031"/>
+    <TTGlyph name="uE0032"/>
+    <TTGlyph name="uE0033"/>
+    <TTGlyph name="uE0034"/>
+    <TTGlyph name="uE0035"/>
+    <TTGlyph name="uE0036"/>
+    <TTGlyph name="uE0037"/>
+    <TTGlyph name="uE0038"/>
+    <TTGlyph name="uE0039"/>
+    <TTGlyph name="uE0061"/>
+    <TTGlyph name="uE0062"/>
+    <TTGlyph name="uE0063"/>
+    <TTGlyph name="uE0064"/>
+    <TTGlyph name="uE0065"/>
+    <TTGlyph name="uE0066"/>
+    <TTGlyph name="uE0067"/>
+    <TTGlyph name="uE0068"/>
+    <TTGlyph name="uE0069"/>
+    <TTGlyph name="uE006A"/>
+    <TTGlyph name="uE006B"/>
+    <TTGlyph name="uE006C"/>
+    <TTGlyph name="uE006D"/>
+    <TTGlyph name="uE006E"/>
+    <TTGlyph name="uE006F"/>
+    <TTGlyph name="uE0070"/>
+    <TTGlyph name="uE0071"/>
+    <TTGlyph name="uE0072"/>
+    <TTGlyph name="uE0073"/>
+    <TTGlyph name="uE0074"/>
+    <TTGlyph name="uE0075"/>
+    <TTGlyph name="uE0076"/>
+    <TTGlyph name="uE0077"/>
+    <TTGlyph name="uE0078"/>
+    <TTGlyph name="uE0079"/>
+    <TTGlyph name="uE007A"/>
+    <TTGlyph name="uE007F"/>
+    <TTGlyph name="u1F3F4"/>
+    <TTGlyph name="uFE82B"/>
+    <TTGlyph name="u1F1E6"/>
+    <TTGlyph name="u1F1E7"/>
+    <TTGlyph name="u1F1E8"/>
+    <TTGlyph name="u1F1E9"/>
+    <TTGlyph name="u1F1EA"/>
+    <TTGlyph name="u1F1EB"/>
+    <TTGlyph name="u1F1EC"/>
+    <TTGlyph name="u1F1ED"/>
+    <TTGlyph name="u1F1EE"/>
+    <TTGlyph name="u1F1EF"/>
+    <TTGlyph name="u1F1F0"/>
+    <TTGlyph name="u1F1F1"/>
+    <TTGlyph name="u1F1F2"/>
+    <TTGlyph name="u1F1F3"/>
+    <TTGlyph name="u1F1F4"/>
+    <TTGlyph name="u1F1F5"/>
+    <TTGlyph name="u1F1F6"/>
+    <TTGlyph name="u1F1F7"/>
+    <TTGlyph name="u1F1F8"/>
+    <TTGlyph name="u1F1F9"/>
+    <TTGlyph name="u1F1FA"/>
+    <TTGlyph name="u1F1FB"/>
+    <TTGlyph name="u1F1FC"/>
+    <TTGlyph name="u1F1FD"/>
+    <TTGlyph name="u1F1FE"/>
+    <TTGlyph name="u1F1FF"/>
+  </glyf>
+
   <name>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2013 Google Inc.

--- a/add_glyphs.py
+++ b/add_glyphs.py
@@ -356,14 +356,14 @@ def add_cmap_format_4(font):
 
   font['cmap'].tables.append(newtable)
 
-def update_font_data(font, seq_to_advance, vadvance, aliases):
+def update_font_data(font, seq_to_advance, vadvance, aliases, add_cmap4):
   """Update the font's cmap, hmtx, GSUB, and GlyphOrder tables."""
   seqs = get_all_seqs(font, seq_to_advance)
   add_glyph_data(font, seqs, seq_to_advance, vadvance)
   add_aliases_to_cmap(font, aliases)
-  add_cmap_format_4(font)
   add_ligature_sequences(font, seqs, aliases)
-
+  if(add_cmap4):
+    add_cmap_format_4(font)
 
 def apply_aliases(seq_dict, aliases):
   """Aliases is a mapping from sequence to replacement sequence.  We can use
@@ -379,7 +379,7 @@ def apply_aliases(seq_dict, aliases):
   return usable_aliases
 
 
-def update_ttx(in_file, out_file, image_dirs, prefix, ext, aliases_file):
+def update_ttx(in_file, out_file, image_dirs, prefix, ext, aliases_file, add_cmap4):
   if ext != '.png':
     raise Exception('extension "%s" not supported' % ext)
 
@@ -403,7 +403,7 @@ def update_ttx(in_file, out_file, image_dirs, prefix, ext, aliases_file):
 
   vadvance = font['vhea'].advanceHeightMax if 'vhea' in font else lineheight
 
-  update_font_data(font, seq_to_advance, vadvance, aliases)
+  update_font_data(font, seq_to_advance, vadvance, aliases, add_cmap4)
 
   font.saveXML(out_file)
 
@@ -426,11 +426,13 @@ def main():
   parser.add_argument(
       '-a', '--aliases', help='process alias table', const='emoji_aliases.txt',
       nargs='?', metavar='file')
+  parser.add_argument(
+      '--add_cmap4', help='add cmap format 4', dest='add_cmap4', action='store_true')
   args = parser.parse_args()
 
   update_ttx(
       args.in_file, args.out_file, args.image_dirs, args.prefix, args.ext,
-      args.aliases)
+      args.aliases, args.add_cmap4)
 
 
 if __name__ == '__main__':

--- a/add_glyphs.py
+++ b/add_glyphs.py
@@ -18,6 +18,8 @@ import sys
 
 from fontTools import ttx
 from fontTools.ttLib.tables import otTables
+from fontTools.ttLib import newTable
+from fontTools.pens.ttGlyphPen import TTGlyphPen
 
 import add_emoji_gsub
 import add_aliases
@@ -158,10 +160,16 @@ def add_glyph_data(font, seqs, seq_to_advance, vadvance):
   #
   # The added codepoints have no advance information, so will get a zero
   # advance.
+  #
+  # An empty glyph will be added to the glyf table to ensure compatibility
+  # with systems requiring a glyf table, like Windows 10.
 
+  pen = TTGlyphPen(None)
+  empty_glyph = pen.glyph()
   cmap = get_font_cmap(font)
   hmtx = font['hmtx'].metrics
   vmtx = font['vmtx'].metrics
+  glyf = font['glyf']
 
   # We don't expect sequences to be in the glyphOrder, since we removed all the
   # single-cp sequences from it and don't expect it to already contain names
@@ -186,6 +194,7 @@ def add_glyph_data(font, seqs, seq_to_advance, vadvance):
     if name not in reverseGlyphMap:
       font.glyphOrder.append(name)
       updatedGlyphOrder=True
+    glyf[name] = empty_glyph
 
   if updatedGlyphOrder:
     delattr(font, '_reverseGlyphOrderDict')

--- a/add_glyphs.py
+++ b/add_glyphs.py
@@ -162,15 +162,16 @@ def add_glyph_data(font, seqs, seq_to_advance, vadvance):
   # The added codepoints have no advance information, so will get a zero
   # advance.
   #
-  # An empty glyph will be added to the glyf table to ensure compatibility
-  # with systems requiring a glyf table, like Windows 10.
+  # If a glyf table is present, empty glyphs will be added to ensure
+  # compatibility with systems requiring a glyf table, like Windows 10.
 
   pen = TTGlyphPen(None)
   empty_glyph = pen.glyph()
   cmap = get_font_cmap(font)
   hmtx = font['hmtx'].metrics
   vmtx = font['vmtx'].metrics
-  glyf = font['glyf']
+  if 'glyf' in font:
+    glyf = font['glyf']
 
   # We don't expect sequences to be in the glyphOrder, since we removed all the
   # single-cp sequences from it and don't expect it to already contain names
@@ -195,7 +196,8 @@ def add_glyph_data(font, seqs, seq_to_advance, vadvance):
     if name not in reverseGlyphMap:
       font.glyphOrder.append(name)
       updatedGlyphOrder=True
-    glyf[name] = empty_glyph
+    if 'glyf' in font:
+      glyf[name] = empty_glyph
 
   if updatedGlyphOrder:
     delattr(font, '_reverseGlyphOrderDict')


### PR DESCRIPTION
This will address https://github.com/googlefonts/noto-emoji/issues/43

- [x] Add glyf table (+ empty glyphs, and loca table)
- [x] Add cmap format 4 table
- [x] Add new binary to codebase
- [x] Produce both versions when running `make` (was: Create flag to add cmap/glyf or not)